### PR TITLE
Add #import syntax support for Jest graphql transformations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,28 @@
 const gql = require('graphql-tag');
 
+function expandImports(source, doc) {
+  const lines = source.split('\n');
+  let outputCode = "";
+
+  lines.some((line) => {
+    if (line[0] === '#' && line.slice(1).split(' ')[0] === 'import') {
+      const importFile = line.slice(1).split(' ')[1];
+      const parseDocument = `require(${importFile})`;
+      const appendDef = `doc.definitions = doc.definitions.concat(${parseDocument}.definitions);`;
+      outputCode += appendDef + "\n";
+    }
+    return (line.length !== 0 && line[0] !== '#');
+  });
+
+  return outputCode;
+}
+
 module.exports = {
   process(src, _filename, _config, _options) {
-    return 'module.exports = ' + JSON.stringify(gql`${src}`) + ';';
+    const doc = gql`${src}`;
+    const outputCode = `var doc = ${JSON.stringify(doc)};`;
+    const importOutputCode = expandImports(src, doc);
+
+    return outputCode + "\n" + importOutputCode + "\n" + `module.exports = doc;`;
   },
 };


### PR DESCRIPTION
Adapted logic from graphql-tag's [webpack loader](https://github.com/apollographql/graphql-tag/blob/master/loader.js) to facilitate the #import syntax described [here](http://dev.apollodata.com/react/webpack.html#Fragments).