### PR TITLE
Use graphql-tag in a pragmatic way

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
-const gql = require('graphql-tag');
+const loader = require('graphql-tag/loader');
 
 module.exports = {
-  process(src, _filename, _config, _options) {
-    return 'module.exports = ' + JSON.stringify(gql`${src}`) + ';';
+  process(src) {
+    // call directly the webpack loader with a mocked context 
+    // as graphql-tag/loader leverages `this.cacheable()`
+    return loader.call({ cacheable() {} }, src);
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-transform-graphql",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Jest transformer for .gql imports",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
     "url": "https://github.com/remind101/jest-transform-graphql/issues"
   },
   "homepage": "https://github.com/remind101/jest-transform-graphql#readme",
-  "dependencies": {
-    "graphql-tag": "^1.1.2"
+  "peerDependencies": {
+    "graphql-tag": "^2.0.0"
   }
 }


### PR DESCRIPTION
> Fixes issues #1, #2, #3.

🕹 Current state
---
The current state of `jest-transform-graphql` depends explicitly on an outdated version of `graphql-tag` _and_ run basically this version of `gql` on source files. 

🚧 Problem
---
We cannot use "evolved" graphql syntax in our files (such as imports) and are tied to an outdated version of `graphql-tag`.

✈️ Straightforward solution
---
Replace the `process` part of this transform by the actual code of `graphql-tag/loader`, such as shown in https://github.com/remind101/jest-transform-graphql/issues/2#issue-209120385 or proposed in https://github.com/remind101/jest-transform-graphql/pull/4.

This code works well and is about nearly the same as [`graphql-tag/loader`, except that we remove the `cacheable` option](https://github.com/apollographql/graphql-tag/blob/07c32a8c24bef51eba336625702b3063c1e314d7/loader.js#L26) used by Webpack. 

🚀 Pragmatic solution
---
> tldr; DRY. 

We can move the latest `graphql-tag` version as a peer dependency and require directly the loader from it. We then call the loader on the source file with a stubbed context so that the `cacheable` function exists.

We do not rewrite the graphql-tag code and leverages it at its best 😊 Thoughts? 💭