### PR TITLE
Compatibility for Jest 28

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports = {
   process(src) {
     // call directly the webpack loader with a mocked context 
     // as graphql-tag/loader leverages `this.cacheable()`
-    return loader.call({ cacheable() {} }, src);
+    return {
+      code: loader.call({ cacheable() {} }, src)
+    };
   },
 };


### PR DESCRIPTION
`jest-transform-graphql` module fails in Jest 28 with this error:

```
Invalid return value:
      `process()` or/and `processAsync()` method of code transformer found at 
      "/Users/evhaus/Git/zenhub/node_modules/jest-transform-graphql/index.js" 
      should return an object or a Promise resolving to an object. The object 
      must have `code` property with a string of processed code.
      This error may be caused by a breaking change in Jest 28:
      https://jestjs.io/docs/upgrading-to-jest28#transformer
      Code Transformation Documentation:
      https://jestjs.io/docs/code-transformation
```

This is due to the change here: https://jestjs.io/docs/upgrading-to-jest28#transformer

Unfortunately this PR will make `jest-transform-graphql` no longer compatible with Jest <=27, so it would need to be published a new major version change.

You can test this PR by installing it your project via this npm dependency definition:

```json
"devDependencies": {
    "jest-transform-graphql": "remind101/jest-transform-graphql#pull/11/head",
}
```