### PR TITLE
fix: support jest v28

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@ const loader = require('graphql-tag/loader');
 
 module.exports = {
   process(src) {
-    // call directly the webpack loader with a mocked context 
+    // call directly the webpack loader with a mocked context
     // as graphql-tag/loader leverages `this.cacheable()`
-    return loader.call({ cacheable() {} }, src);
+    return {
+      code: loader.call({ cacheable() {} }, src),
+    };
   },
 };


### PR DESCRIPTION
According to this jest v28 migration guide, the `process()` method needs to return an object instead of a string.

I've tested this against a work project of mine, and this is working with both jest `v28.1.0` and jest `v27.5.1`.